### PR TITLE
Behold masked editors prompt chars

### DIFF
--- a/Mvczin.Web/Scripts/jquery.validate.unobtrusive.method.cpf.js
+++ b/Mvczin.Web/Scripts/jquery.validate.unobtrusive.method.cpf.js
@@ -22,6 +22,9 @@
         if (cpf) {
             return cpf.trim().replace(/\D/g, '');
         }
+        else {
+            return '';
+        }
     }
 
     function getFirstDigit(cpf) {

--- a/Mvczin.Web/Scripts/jquery.validate.unobtrusive.method.cpf.js
+++ b/Mvczin.Web/Scripts/jquery.validate.unobtrusive.method.cpf.js
@@ -1,10 +1,10 @@
 ﻿(function ($) {
     $.validator.addMethod('cpf', function (value, element) {
-        if (value && value.trim() == '') {
+        var cpf = threatCpf(value);
+
+        if (cpf == '') {
             return true;
         }
-
-        var cpf = threatCpf(value);
 
         var isInvalid = isInvalidLength(cpf) || isNotNumbersOnly(cpf) || isInvalidCpf(cpf) || isInvalidSequence(cpf);
 
@@ -19,7 +19,9 @@
     });
 
     function threatCpf(cpf) {
-        return cpf.trim().replace(/\./gi, '').replace(/-/gi, '');
+        if (cpf) {
+            return cpf.trim().replace(/\D/g, '');
+        }
     }
 
     function getFirstDigit(cpf) {


### PR DESCRIPTION
In order to avoid setting as invalid masked CPF values totally apart of prompt chars and separators chosen, I'd like to suggest these few changes.