### PR TITLE
Behold masked editors prompt chars

### DIFF
--- a/Mvczin.Web/Scripts/jquery.validate.unobtrusive.method.cnpj.js
+++ b/Mvczin.Web/Scripts/jquery.validate.unobtrusive.method.cnpj.js
@@ -22,6 +22,9 @@
         if (cnpj) {
             return cnpj.trim().replace(/\D/g, '');
         }
+        else {
+            return '';
+        }
     }
 
     function getFirstDigit(cnpj) {

--- a/Mvczin.Web/Scripts/jquery.validate.unobtrusive.method.cnpj.js
+++ b/Mvczin.Web/Scripts/jquery.validate.unobtrusive.method.cnpj.js
@@ -1,10 +1,10 @@
 ﻿(function ($) {
     $.validator.addMethod('cnpj', function (value, element) {
-        if (value && value.trim() == '') {
+        var cnpj = threatCnpj(value);
+
+        if (cnpj == '') {
             return true;
         }
-
-        var cnpj = threatCnpj(value);
 
         var isInvalid = isInvalidLength(cnpj) || isNotNumbersOnly(cnpj) || isInvalidCnpj(cnpj) || isInvalidSequence(cnpj);
 
@@ -19,7 +19,9 @@
     });
 
     function threatCnpj(cnpj) {
-        return cnpj.trim().replace(/\./gi, '').replace(/-/gi, '').replace(/\//gi, '');
+        if (cnpj) {
+            return cnpj.trim().replace(/\D/g, '');
+        }
     }
 
     function getFirstDigit(cnpj) {


### PR DESCRIPTION
In order to avoid setting as invalid masked CNPJ values totally apart of prompt chars and separators chosen, I'd like to suggest these few changes.